### PR TITLE
NTI-4650: Make sure to hand over editing to draft on delete

### DIFF
--- a/src/editor/block-types/course-common/Editor.jsx
+++ b/src/editor/block-types/course-common/Editor.jsx
@@ -1,8 +1,12 @@
 export function onRemove (props) {
-	const {blockProps: {removeBlock}} = props;
+	const {blockProps: {removeBlock, setReadOnly}} = props;
 
 	if (removeBlock) {
 		removeBlock();
+	}
+
+	if (setReadOnly) {
+		setReadOnly(false);
 	}
 }
 


### PR DESCRIPTION
We were seeing the code blocks not set read only back to false after clicking the delete button. 

With this change, we would always set readonly false so the editor is editable. 